### PR TITLE
Update DbDiff.php - Table names with special characters 

### DIFF
--- a/DbDiff.php
+++ b/DbDiff.php
@@ -41,7 +41,7 @@ class DbDiff {
 
 		foreach ($tables as $table_name => $fields) {
 
-			$result = mysql_query("SHOW COLUMNS FROM " . $table_name, $db);
+			$result = mysql_query("SHOW COLUMNS FROM `" . $table_name . "`", $db);
 			while ($row = mysql_fetch_assoc($result)) {
 				$tables[$table_name][$row['Field']] = $row;
 			}


### PR DESCRIPTION
Table names with special characters in them would cause the script to fail on the `SHOW COLUMNS` query.